### PR TITLE
Support gelu_pytorch_tanh activation function

### DIFF
--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -5345,6 +5345,7 @@ ACT2FN = {
     'gelu': gelu,
     'gelu_new': gelu,
     'gelu_fast': gelu,
+    'gelu_pytorch_tanh': gelu,
     'geglu': geglu,
     'gegelu': gegelu,
     'identity': identity,


### PR DESCRIPTION
In order to support Gemma 1.1 definition from huggingface (https://huggingface.co/google/gemma-1.1-2b-it/blob/main/config.json) `gelu_pytorch_tanh` activation function should be recognized.